### PR TITLE
Fix playground compilation errors

### DIFF
--- a/tools/playground/playground.cpp
+++ b/tools/playground/playground.cpp
@@ -10,6 +10,10 @@
 #include <ctime>       /* time */
 #include <fsst.h>
 #include <gflags/gflags.h>
+#include <headers/compositecodec.h>
+#include <headers/simdfastpfor.h>
+#include <headers/variablebyte.h>
+#include <headers/blockpacking.h>
 // -------------------------------------------------------------------------------------
 #include "headers/codecfactory.h"
 #include "headers/deltautil.h"

--- a/tools/playground/rle.cpp
+++ b/tools/playground/rle.cpp
@@ -14,7 +14,8 @@ int main() {
    std::srand(std::time(nullptr));
    // -------------------------------------------------------------------------------------
    using namespace FastPForLib;
-   IntegerCODEC &codec = *CODECFactory::getFromName("simdfastpfor256");
+   CODECFactory factory;
+   IntegerCODEC &codec = *factory.getFromName("simdfastpfor256");
    size_t N = 1000 * 1000;
    std::vector<uint32_t> rle_input(N);
    for ( uint32_t i = 0; i < N; i++ ) {


### PR DESCRIPTION
Fix compilation errors in playground.cpp and rle.cpp caused by bumping the FastPFor dependency