### PR TITLE
Bump dependencies

### DIFF
--- a/cmake/aws-sdk.cmake
+++ b/cmake/aws-sdk.cmake
@@ -10,7 +10,7 @@ ExternalProject_Add(
         libawscpp-download
         PREFIX "vendor/libawscpp-download"
         GIT_REPOSITORY "https://github.com/aws/aws-sdk-cpp.git"
-        GIT_TAG "1.9.370"
+        GIT_TAG "1.11.414"
         TIMEOUT 10
         LIST_SEPARATOR "|"
         CMAKE_ARGS

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -8,15 +8,15 @@ find_package(Git REQUIRED)
 # Get rapidjson
 ExternalProject_Add(
     tbb_src
-    PREFIX "vendor/intel/tbb"
-    GIT_REPOSITORY "https://github.com/wjakob/tbb.git"
-    GIT_TAG b066defc0229a1e92d7a200eb3fe0f7e35945d95
+    PREFIX "vendor/intel"
+    GIT_REPOSITORY "https://github.com/oneapi-src/oneTBB.git"
+    GIT_TAG 2a7e0dbe46855b75497355ed3808c31af14a35b6
     TIMEOUT 10
     BUILD_COMMAND  make
     UPDATE_COMMAND "" # to prevent rebuilding everytime
     INSTALL_COMMAND ""
     CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/vendor/tbb_cpp
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/vendor/intel
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
@@ -28,7 +28,7 @@ ExternalProject_Get_Property(tbb_src source_dir)
 ExternalProject_Get_Property(tbb_src binary_dir)
 
 set(TBB_INCLUDE_DIR ${source_dir}/include)
-set(TBB_LIBRARY_PATH ${binary_dir}/libtbb.so)
+set(TBB_LIBRARY_PATH ${binary_dir}/gnu_13.2_cxx11_64_relwithdebinfo/libtbb.so)
 
 file(MAKE_DIRECTORY ${TBB_INCLUDE_DIR})
 

--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -14,8 +14,8 @@ ExternalProject_Add(
     TIMEOUT 10
     BUILD_COMMAND  make
     UPDATE_COMMAND "" # to prevent rebuilding everytime
-    INSTALL_COMMAND ""
     CMAKE_ARGS
+    -DTBB_TEST=OFF
     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/vendor/intel
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -23,12 +23,17 @@ ExternalProject_Add(
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
 )
 
-# Prepare json
-ExternalProject_Get_Property(tbb_src source_dir)
-ExternalProject_Get_Property(tbb_src binary_dir)
+# Prepare tbb
+# ExternalProject_Get_Property(tbb_src source_dir)
+# ExternalProject_Get_Property(tbb_src binary_dir)
+ExternalProject_Get_Property(tbb_src install_dir)
 
-set(TBB_INCLUDE_DIR ${source_dir}/include)
-set(TBB_LIBRARY_PATH ${binary_dir}/gnu_13.2_cxx11_64_relwithdebinfo/libtbb.so)
+set(TBB_INCLUDE_DIR ${install_dir}/include)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(TBB_LIBRARY_PATH ${install_dir}/lib/libtbb_debug.so)
+else()
+    set(TBB_LIBRARY_PATH ${install_dir}/lib/libtbb.so)
+endif()
 
 file(MAKE_DIRECTORY ${TBB_INCLUDE_DIR})
 

--- a/tools/conversion/csvtobtr.cpp
+++ b/tools/conversion/csvtobtr.cpp
@@ -14,8 +14,8 @@
 #include <gflags/gflags.h>
 #include <yaml-cpp/yaml.h>
 #include <spdlog/spdlog.h>
-#include <tbb/parallel_for.h>
-#include <tbb/task_scheduler_init.h>
+#include <oneapi/tbb/global_control.h>
+#include <oneapi/tbb/parallel_for.h>
 // ------------------------------------------------------------------------------
 // Btr internal includes
 #include "common/Utils.hpp"
@@ -72,8 +72,9 @@ int main(int argc, char **argv)
     // This seems necessary to be
     SchemePool::refresh();
 
-    // Init TBB TODO: is that actually still necessary ?
-    tbb::task_scheduler_init init(FLAGS_threads);
+    // Init TBB
+    oneapi::tbb::global_control global_limit(
+      oneapi::tbb::global_control::max_allowed_parallelism, FLAGS_threads);
 
     // Load schema
     const auto schema = YAML::LoadFile(FLAGS_yaml);

--- a/tools/conversion/decompression-speed.cpp
+++ b/tools/conversion/decompression-speed.cpp
@@ -2,11 +2,11 @@
 #include <filesystem>
 #include <fstream>
 #include <random>
-#include <tbb/parallel_for_each.h>
 // -------------------------------------------------------------------------------------
 #include "gflags/gflags.h"
-#include "tbb/parallel_for.h"
-#include "tbb/task_scheduler_init.h"
+#include "oneapi/tbb/global_control.h"
+#include "oneapi/tbb/parallel_for.h"
+#include <oneapi/tbb/parallel_for_each.h>
 // -------------------------------------------------------------------------------------
 #include "common/PerfEvent.hpp"
 #include "common/Utils.hpp"
@@ -108,7 +108,8 @@ int main(int argc, char **argv) {
     } else {
         threads = FLAGS_threads;
     }
-    tbb::task_scheduler_init init(threads);
+    oneapi::tbb::global_control global_limit(
+      oneapi::tbb::global_control::max_allowed_parallelism, FLAGS_threads);
 
     // Read the metadata
     std::vector<char> raw_file_metadata;

--- a/tools/playground/generate_s3_data.cpp
+++ b/tools/playground/generate_s3_data.cpp
@@ -5,8 +5,8 @@
 #include <sstream>
 #include <vector>
 // -------------------------------------------------------------------------------------
-#include <tbb/parallel_for.h>
-#include <tbb/task_scheduler_init.h>
+#include <oneapi/tbb/global_control.h>
+#include <oneapi/tbb/parallel_for.h>
 // -------------------------------------------------------------------------------------
 #include <aws/core/Aws.h>
 #include <aws/s3-crt/S3CrtClient.h>
@@ -101,7 +101,7 @@ static void generate_and_upload_multipart(const Aws::S3Crt::S3CrtClient& s3_clie
     /* Upload parts */
     size_t num_parts = (object_size + part_size - 1) / part_size;
     std::vector<Aws::S3Crt::Model::CompletedPart> completed_parts(num_parts);
-    tbb::parallel_for(size_t(1), num_parts + 1, [&](size_t part_number) {
+    oneapi::tbb::parallel_for(size_t(1), num_parts + 1, [&](size_t part_number) {
       auto sstream = std::make_shared<std::stringstream>();
       generate_data(sstream, std::min(part_size, static_cast<std::size_t>(object_size)));
       auto [success, etag] = upload_part(s3_client, bucket, key, upload_id, part_number, sstream);

--- a/tools/playground/playground.cpp
+++ b/tools/playground/playground.cpp
@@ -10,6 +10,10 @@
 #include <ctime>       /* time */
 #include <fsst.h>
 #include <gflags/gflags.h>
+#include <headers/compositecodec.h>
+#include <headers/simdfastpfor.h>
+#include <headers/variablebyte.h>
+#include <headers/blockpacking.h>
 // -------------------------------------------------------------------------------------
 #include "headers/codecfactory.h"
 #include "headers/deltautil.h"

--- a/tools/playground/rle.cpp
+++ b/tools/playground/rle.cpp
@@ -14,7 +14,8 @@ int main() {
    std::srand(std::time(nullptr));
    // -------------------------------------------------------------------------------------
    using namespace FastPForLib;
-   IntegerCODEC &codec = *CODECFactory::getFromName("simdfastpfor256");
+   CODECFactory factory;
+   IntegerCODEC &codec = *factory.getFromName("simdfastpfor256");
    size_t N = 1000 * 1000;
    std::vector<uint32_t> rle_input(N);
    for ( uint32_t i = 0; i < N; i++ ) {


### PR DESCRIPTION
Due to issues with newest compilers, bump aws and tbb dependencies
For bumping tbb, it seems necessary to move to the new oneapi repository

Important: Merge fix of compilation issues (https://github.com/maxi-k/btrblocks/pull/9) first

Cobined the two PRs should also solve https://github.com/maxi-k/btrblocks/issues/8